### PR TITLE
Maven commits for release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>org.globusonline</groupId>
 	<artifactId>transfer-api-client-java</artifactId>
-	<version>0.10.8</version>
+	<version>0.10.9-SNAPSHOT</version>
 
 	<repositories>
 		<repository>


### PR DESCRIPTION
Heya,

I released 0.10.8 into our maven repo at:

http://code.ceres.auckland.ac.nz/nexus/content/repositories/releases/

This pull request is to include the commits the maven release plugin did into the 'official' transfer-api-client-java github repo.
- Markus
