### PR TITLE
Modified pom.xml to obtain Bouncy Castle jar from Maven central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,9 +80,9 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>bouncycastle</groupId>
+			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk15on</artifactId>
-			<version>154</version>
+			<version>1.54</version>
 		</dependency>
 	</dependencies>
 	<name>GlobusOnline transfer API client in Java</name>


### PR DESCRIPTION
The project doesn't build without modification, due to the Bouncy Castle dependency:

``` text
------------------------------------------------------------------------
Building GlobusOnline transfer API client in Java 0.10.9-SNAPSHOT
------------------------------------------------------------------------
Downloading: http://code.ceres.auckland.ac.nz/nexus/content/groups/public/bouncycastle/bcprov-jdk15on/154/bcprov-jdk15on-154.pom

Downloading: http://repo.maven.apache.org/maven2/bouncycastle/bcprov-jdk15on/154/bcprov-jdk15on-154.pom

The POM for bouncycastle:bcprov-jdk15on:jar:154 is missing, no dependency information available
Downloading: http://code.ceres.auckland.ac.nz/nexus/content/groups/public/bouncycastle/bcprov-jdk15on/154/bcprov-jdk15on-154.jar

Downloading: http://repo.maven.apache.org/maven2/bouncycastle/bcprov-jdk15on/154/bcprov-jdk15on-154.jar

------------------------------------------------------------------------
BUILD FAILURE
------------------------------------------------------------------------
```

This PR modifies `pom.xml` to point at the Bouncy Castle jars in the Maven central repository.
- https://www.bouncycastle.org/latest_releases.html

This change fixes the dependency problem and allows the project to build. :smile: 
